### PR TITLE
Enhancement: track startedJobs state with priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/create-worker.js
+++ b/examples/create-worker.js
@@ -7,7 +7,7 @@
  */
 
 var Firework = require('../modules');
-var queue = Firework.createQueue('https://firework-tests.firebaseio.com');
+var queue = Firework.createQueue('https://firework-tests.firebaseio-demo.com');
 
 module.exports = function () {
   return Firework.createWorker(queue, function (job, callback) {

--- a/examples/generate-work.js
+++ b/examples/generate-work.js
@@ -4,8 +4,8 @@
  */
 
 var Firework = require('../modules');
-var queue = Firework.createQueue('https://firework-tests.firebaseio.com');
-var maxCount = 30;
+var queue = Firework.createQueue('https://firework-tests.firebaseio-demo.com');
+var maxCount = 10;
 var interval = 10;
 
 // Clear all pending/started jobs from the queue.
@@ -20,13 +20,14 @@ var timer = setInterval(function () {
   // Push a new job onto the queue.
   queue.push({
     count: jobCount,
-    time: (new Date).getTime()
+    time: (new Date).getTime(),
+    name: 'monkey' + jobCount
   }, function () {
     console.log('generated job ' + jobCount);
 
     if (++numGeneratedJobs === maxCount)
       process.exit();
-  });
+  }).setPriority(jobCount);
 
   if (count === maxCount)
     clearInterval(timer);

--- a/examples/run-workers.js
+++ b/examples/run-workers.js
@@ -6,14 +6,22 @@
  */
 
 var Firework = require('../modules');
-var queue = Firework.createQueue('https://firework-tests.firebaseio.com');
-var numWorkers = 5;
+var queue = Firework.createQueue('https://firework-tests.firebaseio-demo.com');
+var numWorkers = 1;
 
 // This function is used to create a new worker.
 function createWorker() {
   return Firework.createWorker(queue, function (job, callback) {
     // Simulate variable lengths of time.
-    setTimeout(callback, Math.random() * 2000);
+    var random = parseInt(Math.random() * 1000)
+    console.log('waiting:', random)
+    var error
+    setTimeout(function() {
+      if (random.toString().match(/4/)) {
+        error = 'BAD ' + random
+      }
+      callback(error)
+    }, random);
   });
 }
 

--- a/examples/start-workers.js
+++ b/examples/start-workers.js
@@ -7,7 +7,7 @@
  */
 
 var Firework = require('../modules');
-var queue = Firework.createQueue('https://firework-tests.firebaseio.com');
+var queue = Firework.createQueue('https://firework-tests.firebaseio-demo.com');
 var numWorkers = 5;
 
 for (var i = 0; i < numWorkers; ++i) {

--- a/modules/Worker.js
+++ b/modules/Worker.js
@@ -147,6 +147,7 @@ Worker.prototype = Object.create(EventEmitter.prototype, {
     this.isBusy = true;
 
     var ref = this._nextSnapshot.ref();
+    var priority = this._nextSnapshot.getPriority();
     this._nextSnapshot = null;
 
     var nextJob;
@@ -166,6 +167,7 @@ Worker.prototype = Object.create(EventEmitter.prototype, {
         // Ensure the job has a name.
         if (!nextJob._name)
           nextJob._name = ref.name();
+          nextJob._priority = priority;
 
         // We successfully claimed a job. Start working on it.
         self.startJob(nextJob);


### PR DESCRIPTION
Let me know if you are interested in this idea and if so, if you see any faults in my implementation.

My goal was to track the state of jobs using priority.  This makes it easier to build a web/script UI on top of firework that can show what jobs are running, failed, or completed, without having to loop through all the startedJobs.  I also wanted to be able to add back the original priority when we retry a failed job.

This was implemented by adding a priority to the job based on its state.  When the job is first started, we save the current priority from pendingJobs as the _priority attribute to re-use later.  

Then we set the priority to 'running'.   This is helpful if a SIGKILL stopped the process mid-work.  So when we restart we can find the jobs that didn't finish.  

When a job is completed successfully, its updated with a priority of 'completed'.  This is useful if you just want to clear the completed jobs.

When a job fails, it is marked with a priority of 'failed'.  By setting it as a priority, we can just use an equalTo() to track all the failed jobs, rather than a loop through all startedJobs.

I'm using setWithPriority on this, but we could also do an update followed by setPriority, if you think that makes more sense.

Do you see anything faulty in this logic?  
